### PR TITLE
Get fileName from document.name in uploadDocument

### DIFF
--- a/ide-documents/utils/cmis/document.js
+++ b/ide-documents/utils/cmis/document.js
@@ -20,7 +20,8 @@ function DocumentSerializer(cmisDocument) {
 }
 
 exports.uploadDocument = function (folder, document) {
-	let fileName = document.getName();
+	//check for .name first as it's passed from uploadDocumentOverwrite. Refactor
+	let fileName = document.name ?? document.getName();
 	let mimetype = document.getContentType();
 	let size = document.getSize();
 	let inputStream = document.getInputStream();


### PR DESCRIPTION
When uploadDocument is called from uploadDocumentOverwrite getName() is the old name. The new name is passed in document.name which otherwise is empty.

Fixes: https://github.com/eclipse/dirigible/issues/322